### PR TITLE
Changed libpng12 to libpng

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -12,7 +12,7 @@
 sudo apt-get update -q=2
 sudo apt-get install -q=2 make cmake g++ alsa-base alsa-utils pulseaudio pulseaudio-utils
 # SD2 v2.2
-sudo apt-get install -q=2 libopenscenegraph-dev libsdl2-dev libexpat1-dev libjpeg9-dev libplib-dev libopenal-dev libvorbis-dev libpng12-dev libenet-dev
+sudo apt-get install -q=2 libopenscenegraph-dev libsdl2-dev libexpat1-dev libjpeg9-dev libplib-dev libopenal-dev libvorbis-dev libpng-dev libenet-dev
 # SD2 v2.1
 #sudo apt-get install -q=2 libogg-dev libvorbis-dev libsdl1.2-dev libexpat1-dev libjpeg9-dev libplib-dev libopenal-dev libenet-dev
 


### PR DESCRIPTION
According to
https://askubuntu.com/questions/991706/e-package-libpng12-dev-has-no-installation-candidate#
libpng12-dev is no longer used in Ubuntu 18.04.
I verified that this package has no install candidate on my machine running Ubuntu 18.04.
Therefore I propose this change here.